### PR TITLE
Remove `silent` option

### DIFF
--- a/matterbridge-xiaomi-roborock.schema.json
+++ b/matterbridge-xiaomi-roborock.schema.json
@@ -34,11 +34,6 @@
           "token": {
             "type": "string",
             "description": "The token of the robot vacuum."
-          },
-          "silent": {
-            "type": "boolean",
-            "default": false,
-            "description": "Makes the logs less verbose."
           }
         },
         "required": [

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -49,20 +49,4 @@ describe('getLogger', () => {
     logger[level]('Test message');
     expect(logSpy).toHaveBeenCalledWith('[Name=test][Model=test-model] Test message');
   });
-
-  describe('if silent === true', () => {
-    test.each(['debug', 'info'] as const)('it not should log %p messages', (level) => {
-      const logSpy = jest.spyOn(mockLog, level);
-      const logger = getLogger(mockLog, { name: 'test', silent: true });
-      logger[level]('Test message');
-      expect(logSpy).not.toHaveBeenCalled();
-    });
-
-    test.each(['warn', 'error'] as const)('it should log %p messages', (level) => {
-      const logSpy = jest.spyOn(mockLog, level);
-      const logger = getLogger(mockLog, { name: 'test', silent: true });
-      logger[level]('Test message');
-      expect(logSpy).toHaveBeenCalledWith('[Name=test][Model=unknown] Test message');
-    });
-  });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,14 +5,7 @@ export interface CustomLoggerConfig {
    * The name of the vacuum
    */
   name: string;
-
-  /**
-   * When `true`, info and debug logs are silenced to avoid convoluted logs.
-   */
-  silent?: boolean;
 }
-
-const noop = () => {};
 
 export interface ModelLogger extends Pick<Logger, 'debug' | 'info' | 'warn' | 'error'> {
   setModel: (modelName: string) => void;
@@ -41,8 +34,8 @@ export function getLogger(log: Logger | ModelLogger, config: CustomLoggerConfig)
   }
 
   return {
-    debug: (msg, ...params) => (config.silent ? noop() : log.debug(buildMsg(msg), ...params)),
-    info: (msg, ...params) => (config.silent ? noop() : log.info(buildMsg(msg), ...params)),
+    debug: (msg, ...params) => log.debug(buildMsg(msg), ...params),
+    info: (msg, ...params) => log.info(buildMsg(msg), ...params),
     warn: (msg, ...params) => log.warn(buildMsg(msg), ...params),
     error: (msg, ...params) => log.error(buildMsg(msg), ...params),
     setModel: (modelName) => (model = modelName),


### PR DESCRIPTION
Matterbridge has a great log-level management. 
No need to silence the plugin via internal config.