### PR TITLE
Call raw commands

### DIFF
--- a/.github/workflows/publish-matterbridge-plugin-dev-daily-from-main.yml
+++ b/.github/workflows/publish-matterbridge-plugin-dev-daily-from-main.yml
@@ -2,6 +2,8 @@
 name: Plugin daily dev publish to npm from main branch
 
 on:
+  push:
+    branches: [ main ]
 #  # Daily at midnight UTC
 #  schedule:
 #    - cron: '0 0 * * *'


### PR DESCRIPTION
Let's use the raw commands for the time being... `miio` is highly outdated and fails to validate the responses.

The homebridge plugin had this library entirely overridden, including the `checkResult` helper ([code](https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/blob/dbb90764ed5c57b613565ff38abfba640a7c5fa9/src/miio/lib/checkResult.js#L3)).

Once I have an initial working version for my model, I'll work on forking `miio` and _"making it great again"_.

---

Bonus: I've made my life easier by enabling the release of a new dev NPM package every time I merge into main.