### PR TITLE
No need for the forced initial properties emission

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ import pluginPromise from 'eslint-plugin-promise';
 import pluginJsdoc from 'eslint-plugin-jsdoc';
 import pluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import pluginJest from 'eslint-plugin-jest';
+import unusedImports from 'eslint-plugin-unused-imports';
 
 export default defineConfig([
   {
@@ -113,6 +114,24 @@ export default defineConfig([
 
       // Recommended Jest rules
       ...pluginJest.configs.recommended.rules,
+    },
+  },
+  {
+    plugins: {
+      'unused-imports': unusedImports,
+    },
+    rules: {
+      'no-unused-vars': 'off', // or "@typescript-eslint/no-unused-vars": "off",
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          varsIgnorePattern: '^_',
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
     },
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-n": "17.21.3",
         "eslint-plugin-prettier": "5.5.4",
         "eslint-plugin-promise": "7.2.1",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "30.0.5",
         "npm-check-updates": "18.0.2",
         "prettier": "3.6.2",
@@ -3685,6 +3686,22 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "eslint-plugin-n": "17.21.3",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-promise": "7.2.1",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "30.0.5",
     "npm-check-updates": "18.0.2",
     "prettier": "3.6.2",

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -15,12 +15,12 @@ jest.unstable_mockModule('./vacuum_device_accessory.js', () => ({
 import type { XiaomiRoborockVacuumPlatform } from './xiaomi_roborock_vacuum_platform.js';
 
 const mockLog = {
-  fatal: jest.fn((_message: string, ..._parameters: any[]) => {}),
-  error: jest.fn((_message: string, ..._parameters: any[]) => {}),
-  warn: jest.fn((_message: string, ..._parameters: any[]) => {}),
-  notice: jest.fn((_message: string, ..._parameters: any[]) => {}),
-  info: jest.fn((_message: string, ..._parameters: any[]) => {}),
-  debug: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  fatal: jest.fn(() => {}),
+  error: jest.fn(() => {}),
+  warn: jest.fn(() => {}),
+  notice: jest.fn(() => {}),
+  info: jest.fn(() => {}),
+  debug: jest.fn(() => {}),
 } as unknown as AnsiLogger;
 
 const mockMatterbridge = {
@@ -35,9 +35,9 @@ const mockMatterbridge = {
   getPlugins: jest.fn(() => {
     return [];
   }),
-  addBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
-  removeBridgedEndpoint: jest.fn(async (pluginName: string, device: MatterbridgeEndpoint) => {}),
-  removeAllBridgedEndpoints: jest.fn(async (pluginName: string) => {}),
+  addBridgedEndpoint: jest.fn(async () => {}),
+  removeBridgedEndpoint: jest.fn(async () => {}),
+  removeAllBridgedEndpoints: jest.fn(async () => {}),
 } as unknown as Matterbridge;
 
 const mockConfig = {
@@ -48,7 +48,7 @@ const mockConfig = {
   unregisterOnShutdown: false,
 } as PlatformConfig;
 
-const loggerLogSpy = jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation((level: string, message: string, ...parameters: any[]) => {});
+jest.spyOn(AnsiLogger.prototype, 'log').mockImplementation(() => {});
 
 describe('Matterbridge Xiaomi Roborock Vacuum Plugin', () => {
   let instance: XiaomiRoborockVacuumPlatform;

--- a/src/module.test.ts
+++ b/src/module.test.ts
@@ -15,12 +15,12 @@ jest.unstable_mockModule('./vacuum_device_accessory.js', () => ({
 import type { XiaomiRoborockVacuumPlatform } from './xiaomi_roborock_vacuum_platform.js';
 
 const mockLog = {
-  fatal: jest.fn((message: string, ...parameters: any[]) => {}),
-  error: jest.fn((message: string, ...parameters: any[]) => {}),
-  warn: jest.fn((message: string, ...parameters: any[]) => {}),
-  notice: jest.fn((message: string, ...parameters: any[]) => {}),
-  info: jest.fn((message: string, ...parameters: any[]) => {}),
-  debug: jest.fn((message: string, ...parameters: any[]) => {}),
+  fatal: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  error: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  warn: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  notice: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  info: jest.fn((_message: string, ..._parameters: any[]) => {}),
+  debug: jest.fn((_message: string, ..._parameters: any[]) => {}),
 } as unknown as AnsiLogger;
 
 const mockMatterbridge = {

--- a/src/services/device_manager.test.ts
+++ b/src/services/device_manager.test.ts
@@ -69,6 +69,7 @@ describe('DeviceManager', () => {
       miio.device.matches.mockReturnValue(true);
       miio.device.property.mockReturnValue('cleaning');
       miio.device.properties = { state: 'cleaning', battery: 10 };
+      miio.device.state.mockResolvedValue({ state: 'cleaning', battery: 10 });
       deviceManager = new DeviceManager(log, {
         ip: '192.168.0.1',
         token: 'token',

--- a/src/services/device_manager.ts
+++ b/src/services/device_manager.ts
@@ -27,13 +27,7 @@ export class DeviceManager {
   private readonly internalStateChanged$ = new Subject<StateChangedEvent>();
   private readonly stop$ = new Subject<void>();
   public readonly errorChanged$ = this.internalErrorChanged$.pipe(distinct());
-  public readonly stateChanged$ = concat(
-    defer(() => {
-      const allInitialProps = Object.entries(this.device.properties).map(([key, value]) => ({ key, value }));
-      return from(allInitialProps);
-    }),
-    this.internalStateChanged$,
-  );
+  public readonly stateChanged$ = this.internalStateChanged$.asObservable();
   public readonly deviceConnected$ = this.internalDevice$.pipe(filter(Boolean));
 
   private connectingPromise: Promise<void> | null = null;

--- a/src/services/device_manager.ts
+++ b/src/services/device_manager.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, concat, defer, distinct, exhaustMap, filter, from, Subject, takeUntil, timer } from 'rxjs';
+import { BehaviorSubject, distinct, exhaustMap, filter, Subject, takeUntil, timer } from 'rxjs';
 import * as miio from 'node-miio';
 import type { MiioDevice, MiioErrorChangedEvent, MiioState } from 'node-miio';
 

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -5,13 +5,13 @@ import { getLogger } from './logger.js';
 
 describe('getLogger', () => {
   const mockLog: jest.Mocked<Logger> = {
-    fatal: jest.fn((message: string, ...parameters: any[]) => {}),
-    error: jest.fn((message: string, ...parameters: any[]) => {}),
-    warn: jest.fn((message: string, ...parameters: any[]) => {}),
-    notice: jest.fn((message: string, ...parameters: any[]) => {}),
-    info: jest.fn((message: string, ...parameters: any[]) => {}),
-    debug: jest.fn((message: string, ...parameters: any[]) => {}),
-    log: jest.fn((message: string, ...parameters: any[]) => {}),
+    fatal: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    error: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    warn: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    notice: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    info: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    debug: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    log: jest.fn((_message: string, ..._parameters: any[]) => {}),
   };
 
   beforeEach(() => {

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -5,13 +5,13 @@ import { getLogger } from './logger.js';
 
 describe('getLogger', () => {
   const mockLog: jest.Mocked<Logger> = {
-    fatal: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    error: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    warn: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    notice: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    info: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    debug: jest.fn((_message: string, ..._parameters: any[]) => {}),
-    log: jest.fn((_message: string, ..._parameters: any[]) => {}),
+    fatal: jest.fn(() => {}),
+    error: jest.fn(() => {}),
+    warn: jest.fn(() => {}),
+    notice: jest.fn(() => {}),
+    info: jest.fn(() => {}),
+    debug: jest.fn(() => {}),
+    log: jest.fn(() => {}),
   };
 
   beforeEach(() => {


### PR DESCRIPTION
After fixing the reason why getState was not running periodically, we don't need to force-emit the initial properties.