### PR TITLE
Better support clean modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Next] - ??
 
+### Fixed
+
+- [Clean modes support](https://github.com/afharo/matterbridge-xiaomi-roborock/issues/68): It now handles the cleaning mode changes.
+
 ## [0.1.2] - 2025-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ the [Matterbridge Roborock Platform Plugin](https://www.npmjs.com/package/matter
 ## Features
 
 - Basic RVC operations (start/stop/pause/resume/go back to dock)
+- Fan speed control
+- Water level control (only in supported models)
+- Room cleaning and discovery (only in supported models)
 - Battery information
-- Room cleaning and discovery
 
 ### Room cleaning and discovery
 
@@ -96,7 +98,6 @@ the model (and shown in the Xiaomi Home app):
 ### TODO
 
 - [ ] Improve state control
-- [ ] Get/set the fan speed
 - [ ] Additional controls like initiate dust collection are missing
 - [ ] Add information about the Maintenance counters (sensors, filter, brush)
 - [ ] Add better error handling (expose the errors to the user if possible)

--- a/src/models/speedmodes.ts
+++ b/src/models/speedmodes.ts
@@ -1,10 +1,8 @@
 import { RvcCleanMode } from 'matterbridge/matter/clusters';
 
-import type { ModesHomekitVsMiLevel } from './types.js';
+import type { SpeedModes } from './types.js';
 
-type SimplifiedSpeedModes = Record<string, Array<Omit<ModesHomekitVsMiLevel, 'homekitTopLevel'>>>;
-
-const SPEEDMODES: SimplifiedSpeedModes = {
+const SPEEDMODES: SpeedModes = {
   'gen1': [
     // 0%      = Off / Aus
     {
@@ -342,22 +340,4 @@ const SPEEDMODES: SimplifiedSpeedModes = {
   ],
 };
 
-/**
- *  Formats the SPEEDMODES into a Matter-compatible mode
- *  TODO
- *
- *  @returns {SimplifiedSpeedModes} The formatted speedmodes
- */
-function getMatterSupportedSpeedModes() {
-  // return Object.values(SPEEDMODES).reduce((acc, [gen, modes]) => {
-  //   acc[gen] = modes.map(({ miLevel, name }) => ({
-  //     label: name,
-  //     mode: miLevel,
-  //   }));
-  //
-  //   return acc;
-  // }, {});
-  return SPEEDMODES;
-}
-
-export const speedmodes = getMatterSupportedSpeedModes();
+export const speedmodes = SPEEDMODES;

--- a/src/models/speedmodes.ts
+++ b/src/models/speedmodes.ts
@@ -1,3 +1,5 @@
+import { RvcCleanMode } from 'matterbridge/matter/clusters';
+
 import type { ModesHomekitVsMiLevel } from './types.js';
 
 type SimplifiedSpeedModes = Record<string, Array<Omit<ModesHomekitVsMiLevel, 'homekitTopLevel'>>>;
@@ -8,26 +10,31 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 0-25%  = "Quiet / Leise"
     {
       miLevel: 38,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 26-50%  = "Balanced / Standard"
     {
       miLevel: 60,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 51-75%  = "Turbo / Stark"
     {
       miLevel: 77,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 76-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 90,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   'gen2': [
@@ -35,31 +42,37 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-20%   = "Mop / Mopping / Nur wischen"
     {
       miLevel: 105,
       name: 'Mop',
+      label: RvcCleanMode.ModeTag.Mop,
     },
     // 21-40%  = "Quiet / Leise"
     {
       miLevel: 38,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 41-60%  = "Balanced / Standard"
     {
       miLevel: 60,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 61-80%  = "Turbo / Stark"
     {
       miLevel: 75,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 81-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 100,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   'gen2-no_mop': [
@@ -67,26 +80,31 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 0-25%  = "Quiet / Leise"
     {
       miLevel: 38,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 26-50%  = "Balanced / Standard"
     {
       miLevel: 60,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 51-75%  = "Turbo / Stark"
     {
       miLevel: 75,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 76-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 100,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   'xiaowa-e202-02': [
@@ -94,31 +112,37 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 0-20%  = "Gentle"
     {
       miLevel: 41,
       name: 'Gentle',
+      label: RvcCleanMode.ModeTag.LowEnergy,
     },
     // 20-40%  = "Silent"
     {
       miLevel: 50,
       name: 'Silent',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 40-60%  = "Balanced / Standard"
     {
       miLevel: 68,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 60-80%  = "Turbo / Stark"
     {
       miLevel: 79,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 80-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 100,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   'gen3': [
@@ -126,26 +150,31 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-25%   = "Quiet / Leise"
     {
       miLevel: 101,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 26-50%  = "Balanced / Standard"
     {
       miLevel: 102,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 51-75%  = "Turbo / Stark"
     {
       miLevel: 103,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 76-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 104,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   // S5-Max (https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
@@ -154,31 +183,37 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-20%   = "Soft"
     {
       miLevel: 105,
       name: 'Soft',
+      label: RvcCleanMode.ModeTag.LowEnergy,
     },
     // 21-40%   = "Quiet / Leise"
     {
       miLevel: 101,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 41-60%  = "Balanced / Standard"
     {
       miLevel: 102,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 61-80%  = "Turbo / Stark"
     {
       miLevel: 103,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 81-100% = "Full Speed / Max Speed / Max"
     {
       miLevel: 104,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   // S5-Max + Custom (https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/110)
@@ -187,36 +222,43 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-16%   = "Soft"
     {
       miLevel: 105,
       name: 'Soft',
+      label: RvcCleanMode.ModeTag.LowEnergy,
     },
     // 17-32%   = "Quiet / Leise"
     {
       miLevel: 101,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 33-48%  = "Balanced / Standard"
     {
       miLevel: 102,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 49-64%  = "Turbo / Stark"
     {
       miLevel: 103,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 65-80% = "Full Speed / Max Speed / Max"
     {
       miLevel: 104,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
     // 81-100% = "Custom"
     {
       miLevel: 106,
       name: 'Custom',
+      label: RvcCleanMode.ModeTag.Vacation,
     },
   ],
   // S7 MaxV
@@ -225,36 +267,43 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 0-16%   = "Quiet"
     {
       miLevel: 101,
       name: 'Quiet',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 17-32%   = "Balanced"
     {
       miLevel: 102,
       name: 'Balanced',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 33-49%  = "Turbo"
     {
       miLevel: 103,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 50-66%  = "Max"
     {
       miLevel: 104,
       name: 'Max',
+      label: RvcCleanMode.ModeTag.Max,
     },
     // 67-82% = "Max+"
     {
       miLevel: 108,
       name: 'Max+',
+      label: RvcCleanMode.ModeTag.DeepClean,
     },
     // 83-100% = "Custom"
     {
       miLevel: 106,
       name: 'Custom',
+      label: RvcCleanMode.ModeTag.Vacation,
     },
   ],
 
@@ -264,26 +313,31 @@ const SPEEDMODES: SimplifiedSpeedModes = {
     {
       miLevel: -1,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Vacuum, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 25%      = Silent
     {
       miLevel: 0,
       name: 'Silent',
+      label: RvcCleanMode.ModeTag.LowNoise,
     },
     // 50%      = Standard
     {
       miLevel: 1,
       name: 'Standard',
+      label: RvcCleanMode.ModeTag.Auto,
     },
     // 75%      = Medium
     {
       miLevel: 2,
       name: 'Medium',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 100%      = Turbo
     {
       miLevel: 3,
       name: 'Turbo',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
 };

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -3,10 +3,9 @@ import { RvcCleanMode } from 'matterbridge/matter/clusters';
 import { speedmodes } from './speedmodes.js';
 import { watermodes } from './watermodes.js';
 
-export type SpeedModes = Record<string, ModesHomekitVsMiLevel[]>;
+export type SpeedModes = Record<string, ModesWithMiLevel[]>;
 
-export interface ModesHomekitVsMiLevel {
-  homekitTopLevel: number;
+export interface ModesWithMiLevel {
   miLevel: number;
   name: string;
   label: RvcCleanMode.ModeTag;

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,3 +1,5 @@
+import { RvcCleanMode } from 'matterbridge/matter/clusters';
+
 import { speedmodes } from './speedmodes.js';
 import { watermodes } from './watermodes.js';
 
@@ -7,6 +9,7 @@ export interface ModesHomekitVsMiLevel {
   homekitTopLevel: number;
   miLevel: number;
   name: string;
+  label: RvcCleanMode.ModeTag;
 }
 
 export interface ModelDefinition {

--- a/src/models/watermodes.ts
+++ b/src/models/watermodes.ts
@@ -5,30 +5,26 @@ import type { SpeedModes } from './types.js';
 export const watermodes: SpeedModes = {
   // S5-Max (https://github.com/homebridge-xiaomi-roborock-vacuum/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
   'gen1': [
-    // 0%      = Off
+    // Off
     {
-      homekitTopLevel: 0,
       miLevel: 200,
       name: 'Off',
       label: RvcCleanMode.ModeTag.Mop, // Just setting anything. It doesn't "matter" (pun intended).
     },
-    // 1-35%   = "Light"
+    // "Light"
     {
-      homekitTopLevel: 35,
       miLevel: 201,
       name: 'Light',
       label: RvcCleanMode.ModeTag.Min,
     },
-    // 36-70%  = "Medium"
+    // "Medium"
     {
-      homekitTopLevel: 70,
       miLevel: 202,
       name: 'Medium',
       label: RvcCleanMode.ModeTag.Day,
     },
-    // 71-100% = "High"
+    // "High"
     {
-      homekitTopLevel: 100,
       miLevel: 203,
       name: 'High',
       label: RvcCleanMode.ModeTag.Max,
@@ -36,37 +32,32 @@ export const watermodes: SpeedModes = {
   ],
   // S6-MaxV + Custom
   'gen1+custom': [
-    // 0%      = Off
+    // Off
     {
-      homekitTopLevel: 0,
       miLevel: 200,
       name: 'Off',
       label: RvcCleanMode.ModeTag.Mop, // Just setting anything. It doesn't "matter" (pun intended).
     },
-    // 1-25%   = "Light"
+    // "Light"
     {
-      homekitTopLevel: 25,
       miLevel: 201,
       name: 'Light',
       label: RvcCleanMode.ModeTag.Min,
     },
-    // 26-50%  = "Medium"
+    // "Medium"
     {
-      homekitTopLevel: 50,
       miLevel: 202,
       name: 'Medium',
       label: RvcCleanMode.ModeTag.Day,
     },
-    // 51-75% = "High"
+    // "High"
     {
-      homekitTopLevel: 75,
       miLevel: 203,
       name: 'High',
       label: RvcCleanMode.ModeTag.Max,
     },
-    // 76-100% = "Custom"
+    // "Custom"
     {
-      homekitTopLevel: 100,
       miLevel: 204,
       name: 'Custom',
       label: RvcCleanMode.ModeTag.Vacation,

--- a/src/models/watermodes.ts
+++ b/src/models/watermodes.ts
@@ -1,3 +1,5 @@
+import { RvcCleanMode } from 'matterbridge/matter/clusters';
+
 import type { SpeedModes } from './types.js';
 
 export const watermodes: SpeedModes = {
@@ -8,24 +10,28 @@ export const watermodes: SpeedModes = {
       homekitTopLevel: 0,
       miLevel: 200,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Mop, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-35%   = "Light"
     {
       homekitTopLevel: 35,
       miLevel: 201,
       name: 'Light',
+      label: RvcCleanMode.ModeTag.Min,
     },
     // 36-70%  = "Medium"
     {
       homekitTopLevel: 70,
       miLevel: 202,
       name: 'Medium',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 71-100% = "High"
     {
       homekitTopLevel: 100,
       miLevel: 203,
       name: 'High',
+      label: RvcCleanMode.ModeTag.Max,
     },
   ],
   // S6-MaxV + Custom
@@ -35,30 +41,35 @@ export const watermodes: SpeedModes = {
       homekitTopLevel: 0,
       miLevel: 200,
       name: 'Off',
+      label: RvcCleanMode.ModeTag.Mop, // Just setting anything. It doesn't "matter" (pun intended).
     },
     // 1-25%   = "Light"
     {
       homekitTopLevel: 25,
       miLevel: 201,
       name: 'Light',
+      label: RvcCleanMode.ModeTag.Min,
     },
     // 26-50%  = "Medium"
     {
       homekitTopLevel: 50,
       miLevel: 202,
       name: 'Medium',
+      label: RvcCleanMode.ModeTag.Day,
     },
     // 51-75% = "High"
     {
       homekitTopLevel: 75,
       miLevel: 203,
       name: 'High',
+      label: RvcCleanMode.ModeTag.Max,
     },
     // 76-100% = "Custom"
     {
       homekitTopLevel: 100,
       miLevel: 204,
       name: 'Custom',
+      label: RvcCleanMode.ModeTag.Vacation,
     },
   ],
 };

--- a/src/vacuum_device_accessory.test.mock.ts
+++ b/src/vacuum_device_accessory.test.mock.ts
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 
 import type { DeviceManager, StateChangedEvent } from './services/device_manager.js';
 import { miio } from './test.mocks.js';
+import { findSpeedModes as originalFindSpeedModes } from './utils/find_speed_modes.js';
 
 type PublicMethodsOf<T> = { [K in keyof T]: T[K] };
 
@@ -29,4 +30,11 @@ export const deviceManagerMock: jest.Mocked<PublicMethodsOf<Omit<DeviceManager, 
 
 jest.unstable_mockModule('./services/device_manager.js', () => {
   return { DeviceManager: jest.fn(() => deviceManagerMock) };
+});
+
+export const findSpeedModesMock = jest.fn(originalFindSpeedModes);
+jest.unstable_mockModule('./utils/find_speed_modes.js', () => {
+  return {
+    findSpeedModes: findSpeedModesMock,
+  };
 });

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -1,11 +1,13 @@
 import { jest } from '@jest/globals';
 import type { Logger } from 'matterbridge/logger';
 import { RoboticVacuumCleaner } from 'matterbridge/devices';
-import { ServiceArea } from 'matterbridge/matter/clusters';
+import { PowerSource, RvcCleanMode, RvcOperationalState, RvcRunMode, ServiceArea } from 'matterbridge/matter/clusters';
 import { MatterbridgeServiceAreaServer } from 'matterbridge';
 
-import { deviceManagerMock } from './vacuum_device_accessory.test.mock.js';
+import { deviceManagerMock, findSpeedModesMock } from './vacuum_device_accessory.test.mock.js';
 import type { VacuumDeviceAccessory } from './vacuum_device_accessory.js';
+import { speedmodes } from './models/speedmodes.js';
+import { watermodes } from './models/watermodes.js';
 
 describe('VacuumDeviceAccessory', () => {
   let deviceAccessory: VacuumDeviceAccessory;
@@ -221,6 +223,368 @@ describe('VacuumDeviceAccessory', () => {
             "supportedMaps": [],
           }
         `);
+      });
+    });
+
+    test('should stop the device manager when the destroying lifecycle triggers', async () => {
+      const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
+
+      deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
+
+      const endpoint = await endpointPromise;
+      expect(endpoint).toBeInstanceOf(RoboticVacuumCleaner);
+      endpoint.lifecycle.destroying.emit();
+      expect(deviceManagerMock.stop).toHaveBeenCalledTimes(1);
+    });
+
+    describe('command handlers', () => {
+      let endpoint: RoboticVacuumCleaner;
+
+      beforeEach(async () => {
+        const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
+        deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
+        endpoint = (await endpointPromise) as RoboticVacuumCleaner;
+      });
+
+      describe('changeToMode', () => {
+        test('should have a changeToMode handler', async () => {
+          expect(endpoint.commandHandler.hasHandler('changeToMode')).toBe(true);
+        });
+
+        describe('rvcCleanMode', () => {
+          test('sets the fan speed (but not the water level)', async () => {
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcCleanMode' });
+            expect(deviceManagerMock.device.changeFanSpeed).toHaveBeenCalledWith(105);
+            expect(deviceManagerMock.device.setWaterBoxMode).not.toHaveBeenCalled();
+          });
+
+          test('sets the fan speed and the water level to off (for a supported model)', async () => {
+            findSpeedModesMock.mockReturnValueOnce({
+              speed: speedmodes.gen2,
+              waterspeed: watermodes.gen1,
+            });
+
+            const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
+            deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
+            endpoint = (await endpointPromise) as RoboticVacuumCleaner;
+
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcCleanMode' });
+            await Promise.resolve(); // Just waiting for the pending promises to run
+            expect(deviceManagerMock.device.changeFanSpeed).toHaveBeenCalledWith(105);
+            expect(deviceManagerMock.device.setWaterBoxMode).toHaveBeenCalledWith(200);
+          });
+        });
+
+        describe('rvcRunMode', () => {
+          test('on Idle, it does nothing', async () => {
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcRunMode' });
+            expect(logger.warn).not.toHaveBeenCalled();
+          });
+
+          test('on unknown mode, it logs a warning', async () => {
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 3 }, cluster: 'rvcRunMode' });
+            expect(logger.warn).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Unknown mode 3');
+          });
+
+          test('on Cleaning, it starts a full cleaning if no rooms are selected', async () => {
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 2 }, cluster: 'rvcRunMode' });
+            expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating full cleaning...');
+            expect(deviceManagerMock.device.activateCleaning).toHaveBeenCalled();
+            expect(deviceManagerMock.device.cleanRooms).not.toHaveBeenCalled();
+          });
+
+          test('on Cleaning, it starts a room cleaning if any rooms are selected', async () => {
+            jest.spyOn(endpoint, 'getAttribute').mockReturnValueOnce([16, 17]);
+
+            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 2 }, cluster: 'rvcRunMode' });
+            expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating room cleaning...');
+            expect(deviceManagerMock.device.activateCleaning).not.toHaveBeenCalled();
+            expect(deviceManagerMock.device.cleanRooms).toHaveBeenCalledWith(['16', '17']);
+          });
+        });
+      });
+
+      describe('stop', () => {
+        test('calls deactivate cleaning when triggered', async () => {
+          endpoint.commandHandler.executeHandler('stop');
+          expect(deviceManagerMock.device.deactivateCleaning).toHaveBeenCalled();
+        });
+      });
+
+      describe('pause', () => {
+        test('pauses the current cleaning', async () => {
+          endpoint.commandHandler.executeHandler('pause');
+          expect(deviceManagerMock.device.pause).toHaveBeenCalled();
+        });
+      });
+
+      describe('resume', () => {
+        test('resumes the current full cleaning', async () => {
+          endpoint.commandHandler.executeHandler('resume');
+          expect(deviceManagerMock.device.activateCleaning).toHaveBeenCalled();
+        });
+
+        test('resumes the current room cleaning if areas were previously selected', async () => {
+          jest.spyOn(endpoint, 'getAttribute').mockReturnValueOnce([16, 17]);
+          endpoint.commandHandler.executeHandler('resume');
+          expect(deviceManagerMock.device.resumeCleanRooms).toHaveBeenCalledWith(['16', '17']);
+        });
+      });
+
+      describe('goHome', () => {
+        test('sends the RVC to the charger', async () => {
+          jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
+          endpoint.commandHandler.executeHandler('goHome');
+          await Promise.resolve(); // Just waiting for the pending promises to run
+          expect(deviceManagerMock.device.activateCharging).toHaveBeenCalled();
+        });
+      });
+
+      describe('identify', () => {
+        test('triggers the findme action', async () => {
+          endpoint.commandHandler.executeHandler('identify');
+          expect(deviceManagerMock.device.find).toHaveBeenCalled();
+        });
+      });
+
+      describe('selectAreas', () => {
+        test('sets the selected areas', async () => {
+          const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
+          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } });
+          expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', [17]);
+        });
+
+        test('sets an empty array as selected areas when all rooms are selected', async () => {
+          const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
+          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [16, 17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } });
+          expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', []);
+        });
+      });
+    });
+  });
+
+  describe('postRegister', () => {
+    let endpoint: RoboticVacuumCleaner;
+    let updateAttributeSpy: jest.SpiedFunction<typeof endpoint.updateAttribute>;
+
+    beforeEach(async () => {
+      findSpeedModesMock.mockReturnValueOnce({
+        speed: speedmodes.gen2,
+        waterspeed: watermodes.gen1,
+      });
+
+      const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
+      deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
+      endpoint = (await endpointPromise) as RoboticVacuumCleaner;
+      updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValue(true);
+    });
+
+    describe('serviceAreas hack', () => {
+      test('when no serviceAreas have been discovered, it should enforce empty values', async () => {
+        await deviceAccessory.postRegister();
+        expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'currentArea', null);
+        expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'supportedAreas', []);
+      });
+
+      test("when serviceAreas have been discovered, it shouldn't enforce empty values", async () => {
+        deviceManagerMock.device.getRoomMap.mockResolvedValue([
+          ['16', 'Living room'],
+          ['17', 'Kitchen'],
+        ]);
+
+        const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
+        deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
+        endpoint = (await endpointPromise) as RoboticVacuumCleaner;
+
+        await deviceAccessory.postRegister();
+        expect(updateAttributeSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('stateChangedHandlers', () => {
+      beforeEach(async () => {
+        await deviceAccessory.postRegister();
+      });
+
+      describe('batteryLevel', () => {
+        test('updates the battery level', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'batteryLevel', value: 100 });
+          await Promise.resolve(); // Just waiting for the pending promises to run
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batPercentRemaining', 200);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeLevel', PowerSource.BatChargeLevel.Ok);
+        });
+
+        test('updates the battery level (<20% - Warning)', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'batteryLevel', value: 10 });
+          await Promise.resolve(); // Just waiting for the pending promises to run
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batPercentRemaining', 20);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeLevel', PowerSource.BatChargeLevel.Warning);
+        });
+      });
+
+      describe('charging', () => {
+        test('when charging == true', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'charging', value: true });
+          await Promise.resolve(); // Just waiting for the pending promises to run
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeState', PowerSource.BatChargeState.IsCharging);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Charging);
+        });
+
+        test('when charging == false', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'charging', value: false });
+          await Promise.resolve(); // Just waiting for the pending promises to run
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeState', PowerSource.BatChargeState.IsNotCharging);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      describe('cleaning/in_cleaning', () => {
+        test.each([
+          ['cleaning', true],
+          ['in_cleaning', 1],
+          ['in_cleaning', true],
+        ])('when %s == %s', async (key, value) => {
+          deviceManagerMock.stateChanged$.next({ key, value });
+          await Promise.resolve();
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);
+        });
+
+        test.each([
+          ['cleaning', false],
+          ['in_cleaning', 0],
+          ['in_cleaning', false],
+        ])('when %s == %s', async (key, value) => {
+          deviceManagerMock.stateChanged$.next({ key, value });
+          await Promise.resolve();
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+        });
+      });
+
+      describe('fanSpeed', () => {
+        test('when fanSpeed is known', async () => {
+          deviceManagerMock.device.property.mockReturnValueOnce(200);
+          deviceManagerMock.stateChanged$.next({ key: 'fanSpeed', value: 105 });
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcCleanMode.Cluster.id, 'currentMode', 1);
+        });
+
+        test('when fanSpeed is unknown', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'fanSpeed', value: 999 });
+          expect(updateAttributeSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('water_box_mode', () => {
+        test('when water_box_mode is known', async () => {
+          deviceManagerMock.device.property.mockReturnValueOnce(-1);
+          deviceManagerMock.stateChanged$.next({ key: 'water_box_mode', value: 201 });
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcCleanMode.Cluster.id, 'currentMode', 6);
+        });
+
+        test('when water_box_mode is unknown', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'water_box_mode', value: 999 });
+          expect(updateAttributeSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('state', () => {
+        const awaitNPromises = async (n: number) => {
+          for (let i = 0; i < n; i++) {
+            await Promise.resolve();
+          }
+        };
+
+        test('unknown', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value: 'unknown' });
+          const expectedCalls = 1; // The charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Unknown state: unknown');
+        });
+
+        test('paused', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value: 'paused' });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Paused);
+        });
+
+        test.each(['cleaning', 'spot-cleaning', 'room-cleaning', 'zone-cleaning'])('%s', async (value) => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 2);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);
+        });
+
+        test.each(['returning', 'docking'])('%s', async (value) => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.SeekingCharger);
+        });
+
+        test('error', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value: 'error' });
+          const expectedCalls = 2; // 1 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Error);
+        });
+
+        test('full', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value: 'full' });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Error);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalError', RvcOperationalState.ErrorState.DustBinFull);
+        });
+
+        test.each(['charging-error', 'charger-offline'])('%s', async (value) => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Error);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalError', RvcOperationalState.ErrorState.FailedToFindChargingDock);
+        });
+
+        test.each(['initializing', 'waiting'])('%s', async (value) => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value });
+          const expectedCalls = 3; // 2 + the charging update.
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Stopped);
+        });
+
+        test('charging', async () => {
+          deviceManagerMock.stateChanged$.next({ key: 'state', value: 'charging' });
+          const expectedCalls = 4; // 2 + the charging "true" updates (2).
+          await awaitNPromises(expectedCalls + 1);
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(expectedCalls);
+          expect(logger.warn).not.toHaveBeenCalled();
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Charging);
+        });
       });
     });
   });

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -8,15 +8,19 @@ import { applyConfigDefaults, type Config } from './services/config_service.js';
 import { DeviceManager } from './services/device_manager.js';
 import { getLogger, type ModelLogger } from './utils/logger.js';
 import { findSpeedModes } from './utils/find_speed_modes.js';
+import type { ModelDefinition } from './models/types.js';
+import { MODELS } from './models/models.js';
+
+type SupportedCleanMode = RvcCleanMode.ModeOption & { miLevels: { vacuum: number; mop?: number } };
 
 const SUPPORTED_MODES: RvcRunMode.ModeOption[] = [
-  { label: 'Idle', mode: 0, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
-  { label: 'Cleaning', mode: 1, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
-];
+  { label: 'Idle', mode: 1, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
+  { label: 'Cleaning', mode: 2, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
 
-const SUPPORTED_CLEAN_MODES: RvcCleanMode.ModeOption[] = [
-  { label: 'Vacuum', mode: 0, modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }] },
-  { label: 'Mop', mode: 1, modeTags: [{ value: RvcCleanMode.ModeTag.Mop }] },
+  // I noticed that the matterbridge code has hardcoded 1 and 2 for Idle and Cleaning.
+  // However, upgrading from a pre-existing version will fail if 0 is not a valid mode (because of its persisted state).
+  // TODO: remove it in a few versions.
+  { label: 'Deprecated Idle', mode: 0, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
 ];
 
 const SUPPORTED_OPERATIONAL_STATES: RvcOperationalState.OperationalStateStruct[] = [
@@ -36,6 +40,7 @@ export class VacuumDeviceAccessory {
   private readonly stop$ = new Subject<void>();
   private endpoint?: RoboticVacuumCleaner;
   private serviceAreas: ServiceArea.Area[] = [];
+  private modelSpeeds: ModelDefinition = MODELS.default[0];
 
   constructor(config: Partial<Config>, logger: Logger) {
     this.config = applyConfigDefaults(config);
@@ -61,8 +66,8 @@ export class VacuumDeviceAccessory {
     this.log.info(`Serial number: ${serialNumber}`);
     this.log.info(`Firmware: ${deviceInfo.fw_ver}`);
 
-    const modelSpeeds = findSpeedModes(this.deviceManager.model, deviceInfo.fw_ver);
-    const supportedCleanModes = modelSpeeds.waterspeed ? SUPPORTED_CLEAN_MODES : [SUPPORTED_CLEAN_MODES[0]];
+    this.modelSpeeds = findSpeedModes(this.deviceManager.model, deviceInfo.fw_ver);
+    const supportedCleanModes = this.supportedCleanModes;
 
     this.serviceAreas = await this.getServiceAreas().catch((error) => {
       this.log.warn(`Failed to retrieve service areas: ${error}`);
@@ -100,25 +105,40 @@ export class VacuumDeviceAccessory {
 
     this.endpoint.addCommandHandler('changeToMode', async (data) => {
       this.log.debug(`Start command received: ${JSON.stringify(data)}`);
-      switch (data.request.newMode) {
-        case 0: // Idle
-          // TODO: Confirm what to do here
-          // await this.deviceManager.device.pause();
-          break;
-        case 1: {
-          // Cleaning
-          const selectedAreas = this.selectedAreas;
-          if (selectedAreas.length === 0) {
-            this.log.info(`Initiating full cleaning...`);
-            await this.deviceManager.device.activateCleaning();
-          } else {
-            this.log.info(`Initiating room cleaning...`);
-            await this.deviceManager.device.cleanRooms(selectedAreas);
+      switch (data.cluster) {
+        case 'rvcCleanMode': {
+          // Defines the selected cleaning mode (mop or vacuum)
+          const newCleanMode = supportedCleanModes[data.request.newMode - 1];
+          await this.deviceManager.device.changeFanSpeed(newCleanMode.miLevels.vacuum);
+          if (typeof newCleanMode.miLevels.mop === 'number') {
+            await this.deviceManager.device.setWaterBoxMode(newCleanMode.miLevels.mop);
           }
           break;
         }
-        default:
-          this.log.warn(`Unknown mode ${data.request.newMode}`);
+
+        case 'rvcRunMode':
+          // Actual start command
+          switch (data.request.newMode) {
+            case 1: // Idle
+              // TODO: Confirm what to do here
+              // await this.deviceManager.device.pause();
+              break;
+            case 2: {
+              // Cleaning
+              const selectedAreas = this.selectedAreas;
+              if (selectedAreas.length === 0) {
+                this.log.info(`Initiating full cleaning...`);
+                await this.deviceManager.device.activateCleaning();
+              } else {
+                this.log.info(`Initiating room cleaning...`);
+                await this.deviceManager.device.cleanRooms(selectedAreas);
+              }
+              break;
+            }
+            default:
+              this.log.warn(`Unknown mode ${data.request.newMode}`);
+              break;
+          }
           break;
       }
     });
@@ -201,8 +221,24 @@ export class VacuumDeviceAccessory {
       }
     },
     cleaning: async (cleaning: boolean) => {
-      if (cleaning === false) {
-        await this.endpoint?.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', SUPPORTED_MODES[0].mode);
+      await this.endpoint?.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', cleaning === false ? SUPPORTED_MODES[0].mode : SUPPORTED_MODES[1].mode);
+      if (cleaning) {
+        await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);
+      }
+    },
+    in_cleaning: async (inCleaning: number) => {
+      await this.stateChangedHandlers.cleaning(!!inCleaning);
+    },
+    fanSpeed: async (miLevel: number) => {
+      const cleanMode = this.supportedCleanModes.find(({ miLevels }) => miLevels.vacuum === miLevel);
+      if (cleanMode) {
+        await this.endpoint?.updateAttribute(RvcCleanMode.Cluster.id, 'currentMode', cleanMode.mode);
+      }
+    },
+    water_box_mode: async (miLevel: number) => {
+      const cleanMode = this.supportedCleanModes.find(({ miLevels }) => miLevels.mop === miLevel);
+      if (cleanMode) {
+        await this.endpoint?.updateAttribute(RvcCleanMode.Cluster.id, 'currentMode', cleanMode.mode);
       }
     },
     state: async (state: string) => {
@@ -210,6 +246,7 @@ export class VacuumDeviceAccessory {
       switch (state) {
         case 'cleaning':
         case 'spot-cleaning':
+        case 'room-cleaning':
         case 'zone-cleaning':
           await this.endpoint?.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', SUPPORTED_MODES[1].mode);
           await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);
@@ -217,7 +254,6 @@ export class VacuumDeviceAccessory {
 
         case 'returning': // We might want to emit the optional RvcOperationalState.Cluster.events.operationCompletion when completed cleaning (or when errors occur)
         case 'docking':
-          await this.endpoint?.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', SUPPORTED_MODES[1].mode);
           await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.SeekingCharger);
           break;
 
@@ -326,6 +362,41 @@ export class VacuumDeviceAccessory {
       return [];
     }
     return selectedAreas.map((areaId) => areaId.toString());
+  }
+
+  private get supportedCleanModes(): Array<SupportedCleanMode> {
+    const [vacuumSpeedOff, ...vacuumSpeedModes] = this.modelSpeeds.speed;
+    const [mopSpeedOff, ...mopSpeedModes] = this.modelSpeeds.waterspeed ?? [];
+
+    let mode = 1;
+
+    const supportedCleanModes: SupportedCleanMode[] = vacuumSpeedModes.map(({ name, miLevel, label }) => ({
+      label: `${name} Vacuum`,
+      mode: mode++,
+      modeTags: [
+        // If the label is "Mop", do not add "Vacuum" as a mode tag.
+        ...(label === RvcCleanMode.ModeTag.Mop ? [] : [{ value: RvcCleanMode.ModeTag.Vacuum }]),
+        { value: label },
+      ],
+      miLevels: {
+        vacuum: miLevel,
+        mop: mopSpeedOff?.miLevel,
+      },
+    }));
+
+    mopSpeedModes.forEach(({ name, miLevel, label }) => {
+      supportedCleanModes.push({
+        label: `${name} Mop`,
+        mode: mode++,
+        modeTags: [{ value: RvcCleanMode.ModeTag.Mop }, { value: label }],
+        miLevels: {
+          vacuum: vacuumSpeedOff.miLevel,
+          mop: miLevel,
+        },
+      });
+    });
+
+    return supportedCleanModes;
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

Address #68 by adding support to the clean modes. This includes fan speeds and waterbox levels.

It also bumps the test coverage to 98% (from 70%)!

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
