### PR TITLE
Fix room cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Next] - ??
 
+### Fixed
+
+- [Room cleaning](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/72): It returned _Method `app_segment_clean` is not supported_. The reason was the format of the parameters (Room IDs must be numbers, not strings).
+
 ## [0.2.0] - 2025-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ the model (and shown in the Xiaomi Home app):
       selected the rooms in the app.
 
 > ‼️ If you need to rely on the 2nd approach, chances are that the vacuum does not support the command to run room
-> cleaning (`app_segment_clean`). This is the case for the Roborock S5 (`roborock.vacuum.s5`).
+> cleaning (`app_segment_clean`).
 > If you find the command that works for these models (testing via `node-miio` or `python-miio`), please open an issue
 > or a PR to add this support.
 
@@ -108,7 +108,7 @@ the model (and shown in the Xiaomi Home app):
 
 | Model       | Code name            | Basic info (battery, serial, firmware) | Full cleaning | Room cleaning |
 | ----------- | -------------------- | :------------------------------------: | :-----------: | :-----------: |
-| Roborock S5 | `roborock.vacuum.s5` |                   ✅                   |      ✅       |      ❌       |
+| Roborock S5 | `roborock.vacuum.s5` |                   ✅                   |      ✅       |      ✅       |
 
 ## Known issues
 

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -299,7 +299,7 @@ describe('VacuumDeviceAccessory', () => {
             endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 2 }, cluster: 'rvcRunMode' });
             expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating room cleaning...');
             expect(deviceManagerMock.device.activateCleaning).not.toHaveBeenCalled();
-            expect(deviceManagerMock.device.cleanRooms).toHaveBeenCalledWith(['16', '17']);
+            expect(deviceManagerMock.device.cleanRooms).toHaveBeenCalledWith([16, 17]);
           });
         });
       });
@@ -327,7 +327,7 @@ describe('VacuumDeviceAccessory', () => {
         test('resumes the current room cleaning if areas were previously selected', async () => {
           jest.spyOn(endpoint, 'getAttribute').mockReturnValueOnce([16, 17]);
           endpoint.commandHandler.executeHandler('resume');
-          expect(deviceManagerMock.device.resumeCleanRooms).toHaveBeenCalledWith(['16', '17']);
+          expect(deviceManagerMock.device.resumeCleanRooms).toHaveBeenCalledWith([16, 17]);
         });
       });
 

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -364,13 +364,13 @@ export class VacuumDeviceAccessory {
     return [];
   }
 
-  private get selectedAreas(): string[] {
+  private get selectedAreas(): number[] {
     const selectedAreas = (this.endpoint?.getAttribute(ServiceArea.Cluster.id, 'selectedAreas') as number[] | undefined) ?? [];
     if (selectedAreas.length === this.serviceAreas.length) {
       // If all selected, return empty array to trigger full cleaning
       return [];
     }
-    return selectedAreas.map((areaId) => areaId.toString());
+    return selectedAreas;
   }
 
   private get supportedCleanModes(): Array<SupportedCleanMode> {

--- a/types/node-miio.d.ts
+++ b/types/node-miio.d.ts
@@ -39,8 +39,8 @@ declare module 'node-miio' {
     deactivateCleaning: () => Promise<void>;
     activateCharging: () => Promise<void>;
     pause: () => Promise<void>;
-    cleanRooms: (roomIds: string[]) => Promise<void>;
-    resumeCleanRooms: (roomIds: string[]) => Promise<void>;
+    cleanRooms: (roomIds: number[]) => Promise<void>;
+    resumeCleanRooms: (roomIds: number[]) => Promise<void>;
     fanSpeed: () => Promise<number>;
     changeFanSpeed: (miLevel: number) => Promise<void>;
     getWaterBoxMode: () => Promise<number>;


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

The command to clean rooms expects the room IDs to be numbers instead of strings.

Now, even my old `roborock.vacuum.s5` is able to clean rooms! 🎉 

Related to #68 

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
