### PR TITLE
Disable dev publish on main commits

### DIFF
--- a/.github/workflows/publish-matterbridge-plugin-dev-daily-from-main.yml
+++ b/.github/workflows/publish-matterbridge-plugin-dev-daily-from-main.yml
@@ -2,13 +2,13 @@
 name: Plugin daily dev publish to npm from main branch
 
 on:
-  push:
-    branches: [main]
-  # # Daily at midnight UTC
-  # schedule:
-  #   - cron: '0 0 * * *'
   # Allow manual dispatch
   workflow_dispatch:
+#  push:
+#    branches: [main]
+# # Daily at midnight UTC
+# schedule:
+#   - cron: '0 0 * * *'
 
 jobs:
   publish-dev:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,6 @@ the model (and shown in the Xiaomi Home app):
 
 ## Known issues
 
-| Issue                                                             | Comment                                                                                 |
-| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| The name of the device is not automatically placed in Apple Home. | AFAIK, this happens to all Matterbridge devices (all show as `Matterbridge Accessory`). |
+| Issue                                                             | Comment                                                                                 | Workaround                                  |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------- |
+| The name of the device is not automatically placed in Apple Home. | AFAIK, this happens to all Matterbridge devices (all show as `Matterbridge Accessory`). | The device must be renamed in the Home App. |


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

Now that we're publishing actual releases, there is no need to iterate over the `@dev` tag on every commit.

We can still publish it manually when it makes sense.

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

~- [ ] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.~
~- [ ] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.~
