### PR TITLE
Battery: use `isAtFullCharge` for completeness

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,4 @@
 - [ ] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
       top of the file.
 - [ ] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
+- [ ] Add the appropriate labels to the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Next] - ??
 
+### Changed
+
+- [Battery reports `IsAtFullCharge` when fully charged](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/88): Follow up to the previous version's change. But mostly for consistency and completeness (since iOS makes no visual distinction between `IsAtFullCharge` and `IsNotCharging`).
+
 ## [0.3.0] - 2025-08-22
 
 ### Changed

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -438,7 +438,7 @@ describe('VacuumDeviceAccessory', () => {
           deviceManagerMock.stateChanged$.next({ key: 'charging', value: true });
           await Promise.resolve(); // Just waiting for the pending promises to run
           expect(updateAttributeSpy).toHaveBeenCalledTimes(2);
-          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeState', PowerSource.BatChargeState.IsNotCharging);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(PowerSource.Cluster.id, 'batChargeState', PowerSource.BatChargeState.IsAtFullCharge);
           expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Docked);
         });
 

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -211,18 +211,18 @@ export class VacuumDeviceAccessory {
       await this.endpoint?.updateAttribute(PowerSource.Cluster.id, 'batChargeLevel', getBatteryChargeLevel(level));
     },
     charging: async (charging: boolean) => {
-      const batteryLevel = this.deviceManager.property<number>('batteryLevel') ?? 0;
-      const isChargingAndNotFull = charging === true && batteryLevel < 100;
+      const isCharging = charging === true;
+      const isChargingAndFull = isCharging && this.deviceManager.property<number>('batteryLevel') === 100;
 
       await this.endpoint?.updateAttribute(
         PowerSource.Cluster.id,
         'batChargeState',
-        isChargingAndNotFull ? PowerSource.BatChargeState.IsCharging : PowerSource.BatChargeState.IsNotCharging,
+        isChargingAndFull ? PowerSource.BatChargeState.IsAtFullCharge : isCharging ? PowerSource.BatChargeState.IsCharging : PowerSource.BatChargeState.IsNotCharging,
       );
-      if (isChargingAndNotFull) {
-        await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Charging);
-      } else if (charging === true) {
+      if (isChargingAndFull) {
         await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Docked);
+      } else if (isCharging) {
+        await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Charging);
       }
     },
     cleaning: async (cleaning: boolean) => {


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

Follow up to #86. It now sets the state of the battery as `IsAtFullCharge` (for completeness).

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
