### PR TITLE
Do not report current room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - [Battery reports `IsAtFullCharge` when fully charged](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/88): Follow up to the previous version's change. But mostly for consistency and completeness (since iOS makes no visual distinction between `IsAtFullCharge` and `IsNotCharging`).
+- [Remove Current Room information](TBD): Retrieving the current room is not available yet. Always reporting the first room (even when not cleaning it) is not a great experience. I think that it's better to not report it at all.
 
 ## [0.3.0] - 2025-08-22
 

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -382,11 +382,13 @@ describe('VacuumDeviceAccessory', () => {
     describe('serviceAreas hack', () => {
       test('when no serviceAreas have been discovered, it should enforce empty values', async () => {
         await deviceAccessory.postRegister();
-        expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'currentArea', null);
-        expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'supportedAreas', []);
+        expect(updateAttributeSpy).toHaveBeenCalledTimes(3);
+        expect(updateAttributeSpy).toHaveBeenNthCalledWith(1, ServiceArea.Cluster.id, 'currentArea', null);
+        expect(updateAttributeSpy).toHaveBeenNthCalledWith(2, ServiceArea.Cluster.id, 'currentArea', null);
+        expect(updateAttributeSpy).toHaveBeenNthCalledWith(3, ServiceArea.Cluster.id, 'supportedAreas', []);
       });
 
-      test("when serviceAreas have been discovered, it shouldn't enforce empty values", async () => {
+      test('when serviceAreas have been discovered, it should only force an empty currentArea', async () => {
         deviceManagerMock.device.getRoomMap.mockResolvedValue([
           ['16', 'Living room'],
           ['17', 'Kitchen'],
@@ -395,15 +397,18 @@ describe('VacuumDeviceAccessory', () => {
         const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
         deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
         endpoint = (await endpointPromise) as RoboticVacuumCleaner;
+        updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValue(true);
 
         await deviceAccessory.postRegister();
-        expect(updateAttributeSpy).not.toHaveBeenCalled();
+        expect(updateAttributeSpy).toHaveBeenCalledTimes(1);
+        expect(updateAttributeSpy).toHaveBeenNthCalledWith(1, ServiceArea.Cluster.id, 'currentArea', null);
       });
     });
 
     describe('stateChangedHandlers', () => {
       beforeEach(async () => {
         await deviceAccessory.postRegister();
+        updateAttributeSpy.mockClear();
       });
 
       describe('batteryLevel', () => {

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -190,6 +190,9 @@ export class VacuumDeviceAccessory {
       )
       .subscribe();
 
+    // Force-set the currentArea attribute to null, as we're not able to retrieve the current area at the moment.
+    await this.endpoint?.updateAttribute(ServiceArea.Cluster.id, 'currentArea', null);
+
     // If no areas are found, we need to clear the serviceAreas and the currentArea attributes
     // (the constructor doesn't allow setting them to null as it fallbacks to defaults).
     if (this.serviceAreas.length === 0) {


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

At the moment, the plugin always reports the first room as the current room the RVC is in (even when that room is not being cleaned). This is obviously not true.

This PR fixes it to `null` so that information is not available.

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [ ] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
- [ ] Add the appropriate labels to the PR.
