### PR TITLE
Check `paused` state when handling `in_cleaning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 - [Battery reports `IsAtFullCharge` when fully charged](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/88): Follow up to the previous version's change. But mostly for consistency and completeness (since iOS makes no visual distinction between `IsAtFullCharge` and `IsNotCharging`).
 - [Remove Current Room information](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/94): Retrieving the current room is not available yet. Always reporting the first room (even when not cleaning it) is not a great experience. I think that it's better to not report it at all.
 - [Allow using `roomNames` to override the room names retrieved from the vacuum](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/95): Some RVCs return long numeric names to the rooms instead of the actual names configured in the app. This change allows overriding those retrieved names via the existing `roomNames` setting.
+- [Check `paused` state when handling `in_cleaning`](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/96): To avoid flipping between `paused` and `cleaning` states, the plugin now checks the `paused` state when handling `in_cleaning`.
 
 ## [0.3.0] - 2025-08-22
 

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -468,6 +468,14 @@ describe('VacuumDeviceAccessory', () => {
           expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);
         });
 
+        test('when in_cleaning == 1 but the state is "paused"', async () => {
+          deviceManagerMock.property.mockReturnValueOnce('paused');
+          deviceManagerMock.stateChanged$.next({ key: 'in_cleaning', value: 1 });
+          await Promise.resolve();
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(1);
+          expect(updateAttributeSpy).toHaveBeenCalledWith(RvcRunMode.Cluster.id, 'currentMode', 1);
+        });
+
         test.each([
           ['cleaning', false],
           ['in_cleaning', 0],

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -235,7 +235,11 @@ export class VacuumDeviceAccessory {
       }
     },
     in_cleaning: async (inCleaning: number) => {
-      await this.stateChangedHandlers.cleaning(!!inCleaning);
+      if (this.deviceManager.property<string>('state') === 'paused') {
+        await this.stateChangedHandlers.cleaning(false);
+      } else {
+        await this.stateChangedHandlers.cleaning(!!inCleaning);
+      }
     },
     in_returning: async (inReturning: number) => {
       if (inReturning) {


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

To avoid flipping between `paused` and `cleaning` states, the plugin now checks the `paused` state when handling `in_cleaning`.

Related to #89. 

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
- [x] Add the appropriate labels to the PR.
