### PR TITLE
fix(): selectAreas crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- [Error that impeded selecting rooms](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/274).
+
+## [v0.6.0] - 2026-03-12
+
+### Fixed
+
 - [Assign the first room when cleaning rooms](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/251): As highlighted in [#98](https://github.com/afharo/matterbridge-xiaomi-roborock/issues/98), while in room cleaning mode, the vacuum stays in the state "Traveling". Now the plugin will assign the first room to the vacuum. This is hack until a proper solution is found to retrieve the map (which requires a connection to the Xiaomi Cloud servers).
 
 ## [0.5.0] - 2025-10-16

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import type { Logger } from 'matterbridge/logger';
 import { RoboticVacuumCleaner } from 'matterbridge/devices';
 import { PowerSource, RvcCleanMode, RvcOperationalState, RvcRunMode, ServiceArea } from 'matterbridge/matter/clusters';
-import { MatterbridgeServiceAreaServer } from 'matterbridge';
+import { MatterbridgeServiceAreaServer, type CommandHandlerPayload } from 'matterbridge';
 
 import { deviceManagerMock, findSpeedModesMock } from './vacuum_device_accessory.test.mock.js';
 import type { VacuumDeviceAccessory } from './vacuum_device_accessory.js';
@@ -248,12 +248,13 @@ describe('VacuumDeviceAccessory', () => {
 
       describe('changeToMode', () => {
         test('should have a changeToMode handler', async () => {
-          expect(endpoint.commandHandler.hasHandler('changeToMode')).toBe(true);
+          expect(endpoint.commandHandler.hasHandler('RvcCleanMode.changeToMode')).toBe(true);
+          expect(endpoint.commandHandler.hasHandler('RvcRunMode.changeToMode')).toBe(true);
         });
 
-        describe('rvcCleanMode', () => {
+        describe('RvcCleanMode.changeToMode', () => {
           test('sets the fan speed (but not the water level)', async () => {
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcCleanMode' });
+            endpoint.commandHandler.executeHandler('RvcCleanMode.changeToMode', { request: { newMode: 1 } } as unknown as CommandHandlerPayload<'RvcCleanMode.changeToMode'>);
             expect(deviceManagerMock.device.changeFanSpeed).toHaveBeenCalledWith(105);
             expect(deviceManagerMock.device.setWaterBoxMode).not.toHaveBeenCalled();
           });
@@ -268,26 +269,26 @@ describe('VacuumDeviceAccessory', () => {
             deviceManagerMock.deviceConnected$.next(deviceManagerMock.device);
             endpoint = (await endpointPromise) as RoboticVacuumCleaner;
 
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcCleanMode' });
+            endpoint.commandHandler.executeHandler('RvcCleanMode.changeToMode', { request: { newMode: 1 } } as unknown as CommandHandlerPayload<'RvcCleanMode.changeToMode'>);
             await Promise.resolve(); // Just waiting for the pending promises to run
             expect(deviceManagerMock.device.changeFanSpeed).toHaveBeenCalledWith(105);
             expect(deviceManagerMock.device.setWaterBoxMode).toHaveBeenCalledWith(200);
           });
         });
 
-        describe('rvcRunMode', () => {
+        describe('RvcRunMode.changeToMode', () => {
           test('on Idle, it does nothing', async () => {
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 1 }, cluster: 'rvcRunMode' });
+            endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 1 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
             expect(logger.warn).not.toHaveBeenCalled();
           });
 
           test('on unknown mode, it logs a warning', async () => {
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 3 }, cluster: 'rvcRunMode' });
+            endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 3 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
             expect(logger.warn).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Unknown mode 3');
           });
 
           test('on Cleaning, it starts a full cleaning if no rooms are selected', async () => {
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 2 }, cluster: 'rvcRunMode' });
+            endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 2 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
             expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating full cleaning...');
             expect(deviceManagerMock.device.activateCleaning).toHaveBeenCalled();
             expect(deviceManagerMock.device.cleanRooms).not.toHaveBeenCalled();
@@ -296,7 +297,7 @@ describe('VacuumDeviceAccessory', () => {
           test('on Cleaning, it starts a room cleaning if any rooms are selected', async () => {
             jest.spyOn(endpoint, 'getAttribute').mockReturnValueOnce([16, 17]);
 
-            endpoint.commandHandler.executeHandler('changeToMode', { request: { newMode: 2 }, cluster: 'rvcRunMode' });
+            endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 2 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
             expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating room cleaning...');
             expect(deviceManagerMock.device.activateCleaning).not.toHaveBeenCalled();
             expect(deviceManagerMock.device.cleanRooms).toHaveBeenCalledWith([16, 17]);
@@ -306,27 +307,27 @@ describe('VacuumDeviceAccessory', () => {
 
       describe('stop', () => {
         test('calls deactivate cleaning when triggered', async () => {
-          endpoint.commandHandler.executeHandler('stop');
+          endpoint.commandHandler.executeHandler('stop', { request: {} } as unknown as CommandHandlerPayload<'stop'>);
           expect(deviceManagerMock.device.deactivateCleaning).toHaveBeenCalled();
         });
       });
 
       describe('pause', () => {
         test('pauses the current cleaning', async () => {
-          endpoint.commandHandler.executeHandler('pause');
+          endpoint.commandHandler.executeHandler('pause', { request: {} } as unknown as CommandHandlerPayload<'pause'>);
           expect(deviceManagerMock.device.pause).toHaveBeenCalled();
         });
       });
 
       describe('resume', () => {
         test('resumes the current full cleaning', async () => {
-          endpoint.commandHandler.executeHandler('resume');
+          endpoint.commandHandler.executeHandler('resume', { request: {} } as unknown as CommandHandlerPayload<'resume'>);
           expect(deviceManagerMock.device.activateCleaning).toHaveBeenCalled();
         });
 
         test('resumes the current room cleaning if areas were previously selected', async () => {
           jest.spyOn(endpoint, 'getAttribute').mockReturnValueOnce([16, 17]);
-          endpoint.commandHandler.executeHandler('resume');
+          endpoint.commandHandler.executeHandler('resume', { request: {} } as unknown as CommandHandlerPayload<'resume'>);
           expect(deviceManagerMock.device.resumeCleanRooms).toHaveBeenCalledWith([16, 17]);
         });
       });
@@ -334,7 +335,7 @@ describe('VacuumDeviceAccessory', () => {
       describe('goHome', () => {
         test('sends the RVC to the charger', async () => {
           jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
-          endpoint.commandHandler.executeHandler('goHome');
+          endpoint.commandHandler.executeHandler('goHome', { request: {} } as unknown as CommandHandlerPayload<'goHome'>);
           await Promise.resolve(); // Just waiting for the pending promises to run
           expect(deviceManagerMock.device.activateCharging).toHaveBeenCalled();
         });
@@ -342,7 +343,7 @@ describe('VacuumDeviceAccessory', () => {
 
       describe('identify', () => {
         test('triggers the findme action', async () => {
-          endpoint.commandHandler.executeHandler('identify');
+          endpoint.commandHandler.executeHandler('identify', { request: {} } as unknown as CommandHandlerPayload<'identify'>);
           expect(deviceManagerMock.device.find).toHaveBeenCalled();
         });
       });
@@ -350,13 +351,13 @@ describe('VacuumDeviceAccessory', () => {
       describe('selectAreas', () => {
         test('sets the selected areas', async () => {
           const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
-          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } });
+          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } } as unknown as CommandHandlerPayload<'selectAreas'>);
           expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', [17]);
         });
 
         test('sets an empty array as selected areas when all rooms are selected', async () => {
           const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
-          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [16, 17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } });
+          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [16, 17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } } as unknown as CommandHandlerPayload<'selectAreas'>);
           expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', []);
         });
       });

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -351,13 +351,19 @@ describe('VacuumDeviceAccessory', () => {
       describe('selectAreas', () => {
         test('sets the selected areas', async () => {
           const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
-          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } } as unknown as CommandHandlerPayload<'selectAreas'>);
+          endpoint.commandHandler.executeHandler('selectAreas', {
+            request: { newAreas: [17] },
+            attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] },
+          } as unknown as CommandHandlerPayload<'selectAreas'>);
           expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', [17]);
         });
 
         test('sets an empty array as selected areas when all rooms are selected', async () => {
           const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
-          endpoint.commandHandler.executeHandler('selectAreas', { request: { newAreas: [16, 17] }, attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] } } as unknown as CommandHandlerPayload<'selectAreas'>);
+          endpoint.commandHandler.executeHandler('selectAreas', {
+            request: { newAreas: [16, 17] },
+            attributes: { supportedAreas: [{ areaId: 16 }, { areaId: 17 }] },
+          } as unknown as CommandHandlerPayload<'selectAreas'>);
           expect(updateAttributeSpy).toHaveBeenCalledWith(ServiceArea.Cluster.id, 'selectedAreas', []);
         });
       });

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -103,47 +103,42 @@ export class VacuumDeviceAccessory {
       this.deviceManager.stop();
     });
 
-    this.endpoint.addCommandHandler('changeToMode', async (data) => {
-      this.log.debug(`Start command received: ${JSON.stringify(data)}`);
-      switch (data.cluster) {
-        case 'rvcCleanMode': {
-          // Defines the selected cleaning mode (mop or vacuum)
-          const newCleanMode = supportedCleanModes[data.request.newMode - 1];
-          await this.deviceManager.device.changeFanSpeed(newCleanMode.miLevels.vacuum);
-          if (typeof newCleanMode.miLevels.mop === 'number') {
-            await this.deviceManager.device.setWaterBoxMode(newCleanMode.miLevels.mop);
+    this.endpoint.addCommandHandler('RvcCleanMode.changeToMode', async (data) => {
+      // Defines the selected cleaning mode (mop or vacuum)
+      const newCleanMode = supportedCleanModes[data.request.newMode - 1];
+      await this.deviceManager.device.changeFanSpeed(newCleanMode.miLevels.vacuum);
+      if (typeof newCleanMode.miLevels.mop === 'number') {
+        await this.deviceManager.device.setWaterBoxMode(newCleanMode.miLevels.mop);
+      }
+    });
+
+    this.endpoint.addCommandHandler('RvcRunMode.changeToMode', async (data) => {
+      // Actual start command
+      switch (data.request.newMode) {
+        case 1: // Idle
+          // TODO: Confirm what to do here
+          // await this.deviceManager.device.pause();
+          break;
+        case 2: {
+          // Cleaning
+          const selectedAreas = this.selectedAreas;
+          if (selectedAreas.length === 0) {
+            this.log.info(`Initiating full cleaning...`);
+            await this.deviceManager.device.activateCleaning();
+          } else {
+            this.log.info(`Initiating room cleaning...`);
+            await this.deviceManager.device.cleanRooms(selectedAreas);
+            // HACK: Assign the first selected area as the current area so that we can control speeds while room cleaning
+            await this.endpoint?.updateAttribute(ServiceArea.Cluster.id, 'currentArea', selectedAreas[0]);
           }
           break;
         }
-
-        case 'rvcRunMode':
-          // Actual start command
-          switch (data.request.newMode) {
-            case 1: // Idle
-              // TODO: Confirm what to do here
-              // await this.deviceManager.device.pause();
-              break;
-            case 2: {
-              // Cleaning
-              const selectedAreas = this.selectedAreas;
-              if (selectedAreas.length === 0) {
-                this.log.info(`Initiating full cleaning...`);
-                await this.deviceManager.device.activateCleaning();
-              } else {
-                this.log.info(`Initiating room cleaning...`);
-                await this.deviceManager.device.cleanRooms(selectedAreas);
-                // HACK: Assign the first selected area as the current area so that we can control speeds while room cleaning
-                await this.endpoint?.updateAttribute(ServiceArea.Cluster.id, 'currentArea', selectedAreas[0]);
-              }
-              break;
-            }
-            default:
-              this.log.warn(`Unknown mode ${data.request.newMode}`);
-              break;
-          }
+        default:
+          this.log.warn(`Unknown mode ${data.request.newMode}`);
           break;
       }
     });
+
     this.endpoint.addCommandHandler('stop', async () => {
       await this.deviceManager.device.deactivateCleaning();
     });
@@ -166,7 +161,7 @@ export class VacuumDeviceAccessory {
       await this.deviceManager.device.find();
     });
     this.endpoint.addCommandHandler('selectAreas', async (data) => {
-      this.log.debug(`Select areas command received: ${JSON.stringify(data)}`);
+      this.log.debug(`Select areas command received: ${data.request.newAreas}`);
       let selectedAreas = data.request.newAreas;
       if ((data.attributes.supportedAreas as ServiceArea.Area[])?.length === selectedAreas.length) {
         selectedAreas = []; // Force empty if all areas are selected
@@ -231,6 +226,9 @@ export class VacuumDeviceAccessory {
       }
     },
     cleaning: async (cleaning: boolean) => {
+      if (this.deviceManager.property('state') === 'error' || this.deviceManager.property('state') === 'paused') {
+        return; // Do not update the state if there is an error or paused
+      }
       await this.endpoint?.updateAttribute(RvcRunMode.Cluster.id, 'currentMode', cleaning === false ? SUPPORTED_MODES[0].mode : SUPPORTED_MODES[1].mode);
       if (cleaning) {
         await this.endpoint?.updateAttribute(RvcOperationalState.Cluster.id, 'operationalState', RvcOperationalState.OperationalState.Running);


### PR DESCRIPTION
## Description

<!-- Provide an explanation of the changes, the motivation, and link it to any issue if it exists (e.g. fixes #321). -->

Resolves #270 
Resolves #269 
Resolves https://github.com/Luligu/matterbridge/issues/546

As an extra, it tries to avoid the scenario where it comes back and forth between error and cleaning state (as well as paused and cleaning states).

## Checklist

<!--
  Make sure to check the following and tick the boxes once they are done.
  Strike them through (wrap them in between ~) if you don't think that these are necessary for this PR.
-->

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the
      top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
- [x] Add the appropriate labels to the PR.
