### PR TITLE
fix: resolve Matter transaction deadlock on goHome and handle Idle mode (fixes #273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Next] - ??
 
+### Fixed
+
+- Resolves Matter transaction deadlock on `goHome` command by removing redundant `await updateAttribute` call within the command handler, which blocked Matter interaction transactions (fixes [#273](https://github.com/afharo/matterbridge-xiaomi-roborock/issues/273)).
+- Implements `RvcRunMode.changeToMode` Idle mode (mode 1) to send the vacuum back to the dock rather than an empty `break`.
+- Fixes `in_returning` state handler unintentionally overriding paused status when the vacuum is paused while returning to the dock.
+- Adds support for `'disable'` status in timer definitions for room cleaning discovery on Roborock models.
+
 ## [v0.7.0] - 2026-09-08
 
 - [Fix recent breaking changes from matterbridge](https://github.com/afharo/matterbridge-xiaomi-roborock/pull/352)

--- a/src/vacuum_device_accessory.test.ts
+++ b/src/vacuum_device_accessory.test.ts
@@ -110,8 +110,8 @@ describe('VacuumDeviceAccessory', () => {
         deviceManagerMock.device.getTimer.mockResolvedValue([
           // This one will be discarded because it's ON
           ['timer-id', 'on', ['0 0 * * *', ['action', { segments: '16,17' }]]],
-          // This one is taken
-          ['timer-id', 'off', ['0 0 * * *', ['action', { segments: '16,17' }]]],
+          // This one is taken (supports off, disabled, disable)
+          ['timer-id', 'disable', ['0 0 * * *', ['action', { segments: '16,17' }]]],
         ]);
 
         const endpointPromise = deviceAccessory.initializeMatterbridgeEndpoint();
@@ -287,6 +287,11 @@ describe('VacuumDeviceAccessory', () => {
             expect(logger.warn).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Unknown mode 3');
           });
 
+          test('on Idle, it sends the RVC to the charger', async () => {
+            endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 1 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
+            expect(deviceManagerMock.device.activateCharging).toHaveBeenCalled();
+          });
+
           test('on Cleaning, it starts a full cleaning if no rooms are selected', async () => {
             endpoint.commandHandler.executeHandler('RvcRunMode.changeToMode', { request: { newMode: 2 } } as unknown as CommandHandlerPayload<'RvcRunMode.changeToMode'>);
             expect(logger.info).toHaveBeenCalledWith('[Name=Test Vacuum][Model=unknown] Initiating full cleaning...');
@@ -333,11 +338,12 @@ describe('VacuumDeviceAccessory', () => {
       });
 
       describe('goHome', () => {
-        test('sends the RVC to the charger', async () => {
-          jest.spyOn(endpoint, 'updateAttribute').mockResolvedValueOnce(true);
+        test('sends the RVC to the charger without deadlock from updating attributes directly', async () => {
+          const updateAttributeSpy = jest.spyOn(endpoint, 'updateAttribute');
           endpoint.commandHandler.executeHandler('goHome', { request: {} } as unknown as CommandHandlerPayload<'goHome'>);
           await Promise.resolve(); // Just waiting for the pending promises to run
           expect(deviceManagerMock.device.activateCharging).toHaveBeenCalled();
+          expect(updateAttributeSpy).not.toHaveBeenCalled();
         });
       });
 
@@ -504,6 +510,13 @@ describe('VacuumDeviceAccessory', () => {
           await Promise.resolve();
           expect(updateAttributeSpy).toHaveBeenCalledTimes(1);
           expect(updateAttributeSpy).toHaveBeenCalledWith(RvcOperationalState, 'operationalState', RvcOperationalState.OperationalState.SeekingCharger);
+        });
+
+        test('when paused, in_returning does not override paused state', async () => {
+          deviceManagerMock.device.property.mockReturnValue('paused');
+          deviceManagerMock.stateChanged$.next({ key: 'in_returning', value: 1 });
+          await Promise.resolve();
+          expect(updateAttributeSpy).toHaveBeenCalledTimes(0);
         });
 
         test.each([

--- a/src/vacuum_device_accessory.ts
+++ b/src/vacuum_device_accessory.ts
@@ -112,8 +112,7 @@ export class VacuumDeviceAccessory {
       // Actual start command
       switch (data.request.newMode) {
         case 1: // Idle
-          // TODO: Confirm what to do here
-          // await this.deviceManager.device.pause();
+          await this.deviceManager.device.activateCharging();
           break;
         case 2: {
           // Cleaning
@@ -150,7 +149,6 @@ export class VacuumDeviceAccessory {
       }
     });
     this.endpoint.addCommandHandler('goHome', async () => {
-      await this.endpoint?.updateAttribute(RvcOperationalState, 'operationalState', RvcOperationalState.OperationalState.SeekingCharger);
       await this.deviceManager.device.activateCharging();
     });
     this.endpoint.addCommandHandler('identify', async () => {
@@ -238,6 +236,9 @@ export class VacuumDeviceAccessory {
       }
     },
     in_returning: async (inReturning: number) => {
+      if (this.deviceManager.property('state') === 'paused') {
+        return;
+      }
       if (inReturning) {
         await this.endpoint?.updateAttribute(RvcOperationalState, 'operationalState', RvcOperationalState.OperationalState.SeekingCharger);
       }
@@ -340,7 +341,7 @@ export class VacuumDeviceAccessory {
     const timers = await this.deviceManager.device.getTimer();
     if (timers.length > 0) {
       const timer = timers.find(([id, status, definition]) => {
-        if (['off', 'disabled'].includes(status)) {
+        if (['off', 'disabled', 'disable'].includes(status)) {
           const [cronExpression, action] = definition;
           // Who sets up a timer that runs at midnight for a Vacuum Cleaner? This should be it.
           if (cronExpression.startsWith('0 0 * *')) {


### PR DESCRIPTION
## Description

This PR resolves the issue where pressing "Return to Dock" (or sending the `goHome` command) from Apple Home / Matter controllers hangs indefinitely and fails to return the robot to its dock (fixes #273).

### Root Cause
When a Matter controller invokes `goHome`, Matter.js executes the handler inside an active command transaction (`invoke`). In the previous implementation:
```typescript
this.endpoint.addCommandHandler(\x27goHome\x27, async () => {
  await this.endpoint?.updateAttribute(RvcOperationalState, \x27operationalState\x27, RvcOperationalState.OperationalState.SeekingCharger);
  await this.deviceManager.device.activateCharging();
});
```
Calling `await this.endpoint?.updateAttribute(...)` queues an attribute update transaction (`setStateOf`), which is blocked waiting for the parent `invoke` transaction to complete before acquiring the state lock. Because `updateAttribute` was awaited inside the handler, neither transaction could proceed, resulting in a circular transaction deadlock on Matterbridge:
```text
[InteractionServer] Invoke « ... rvcOperationalState.goHome
[ProtocolService] Invoke « RoborockS5...rvcOperationalState.goHome
[Transaction] Tx ◦setStateOf<RoborockS5...>#ce waiting on @1:...✉...
```
Matter controllers (such as Apple Home) eventually time out waiting for the command response.

### Changes
1. **Remove `await updateAttribute` inside `goHome`**: Rely on `stateChangedHandlers.in_returning` and `stateChangedHandlers.state` (which already handle updating `operationalState` to `SeekingCharger` reactively when the vacuum actually transitions to returning/docking). This eliminates the transaction deadlock completely.
2. **Handle `RvcRunMode.changeToMode(1)` (Idle mode)**: Fulfill the existing `TODO` in `RvcRunMode.changeToMode` by calling `activateCharging()` when Idle mode is requested, ensuring switching to Idle from Apple Home directs the vacuum to the dock.
3. **Prevent `in_returning` from overriding `paused` status**: When returning is paused, some firmwares continue reporting `in_returning: 1`. Checking `this.deviceManager.property(\x27state\x27) !== \x27paused\x27` ensures the `paused` operational state is preserved.
4. **Support `\x27disable\x27` timer status**: Accept `\x27disable\x27` (in addition to `\x27off\x27` and `\x27disabled\x27`) when discovering room segments from midnight timers on Roborock firmwares.
5. **Tests**: Updated and added unit tests in `src/vacuum_device_accessory.test.ts` covering Idle mode, deadlock-free `goHome`, paused returning state, and timer status parsing.

Special thanks to @nadorjozsef who previously investigated this in #273 and shared initial findings in their fork.

## Checklist

- [x] Update the CHANGELOG.md file, including a description of the changes, following the convention commented at the top of the file.
- [x] Add tests for the new code that you just changed. We'd like to keep the coverage as close to 100% as possible.
- [x] Add the appropriate labels to the PR.